### PR TITLE
fix: Bump memory for the court document packer

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -3,6 +3,7 @@ resource "aws_lambda_function" "court_document_pack" {
   package_type  = "Image"
   function_name = local.lambda_name_court_document_pack
   role          = aws_iam_role.court_document_pack_sf_lambda_role.arn
+  memory_size   = 256
   timeout       = 300
 
   environment {


### PR DESCRIPTION
We have observed what looks like an OOM failure in the v2 packer for a document with a large number of images. This doubles the memory we allocate to the lambda to mitigate against this in future